### PR TITLE
Fixing single use supply and revenue item pkey bug

### DIFF
--- a/database/schema_updates/changelogs/20220412_cleanup_packages.sql
+++ b/database/schema_updates/changelogs/20220412_cleanup_packages.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset fcerny:1
+--changeset fcerny:1 endDelimiter:"/"
 -- We renamed the test_trigger package to test_tool_triggers, so we need to drop it
 -- Reference: https://stackoverflow.com/questions/34151428/drop-trigger-only-if-it-exists-oracle
 declare 

--- a/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
+++ b/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
@@ -5,7 +5,7 @@ declare
   l_count integer;
 begin
     SELECT count(*) INTO l_count FROM USER_CONSTRAINTS 
-    WHERE CONSTRAINT_NAME='BSA_REVENUE_ITEM_UK';
+    WHERE CONSTRAINT_NAME='BSA_SINGLE_USE_SUPPLY_UK';
 
     if l_count > 0 then 
         execute immediate 'alter table bsa_single_use_supply drop constraint bsa_single_use_supply_uk';

--- a/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
+++ b/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
@@ -13,7 +13,7 @@ begin
 end;
 /
 
---changest fcerny:2 
+--changeset fcerny:2 
 -- Add a new constraint back
 alter table bsa_single_use_supply
 ADD constraint bsa_single_use_supply_uk unique (project_id, name);

--- a/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
+++ b/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset fcerny:1
+alter table bsa_single_use_supply
+DROP constraint bsa_single_use_supply_uk;
+
+--changest fcerny:2
+-- Add a new constraint back
+alter table bsa_single_use_supply
+ADD constraint bsa_single_use_supply_uk unique (project_id, name);
+
+--changeset fcerny:3
+-- Do the same for revenue items, dropping first to aid in testing
+alter table bsa_revenue_item
+DROP constraint bsa_revenue_item_uk;
+
+--changeset fcerny:4
+alter table bsa_revenue_item
+ADD constraint bsa_revenue_item_uk unique (project_id, name);

--- a/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
+++ b/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
@@ -1,8 +1,17 @@
 --liquibase formatted sql
 
 --changeset fcerny:1
-alter table bsa_single_use_supply
-DROP constraint bsa_single_use_supply_uk;
+declare 
+  l_count integer;
+begin
+    SELECT count(*) INTO l_count FROM USER_CONSTRAINTS 
+    WHERE CONSTRAINT_NAME='BSA_REVENUE_ITEM_UK';
+
+    if l_count > 0 then 
+        execute immediate 'alter table bsa_single_use_supply drop constraint bsa_single_use_supply_uk';
+    end if;
+end;
+/
 
 --changest fcerny:2
 -- Add a new constraint back
@@ -11,8 +20,18 @@ ADD constraint bsa_single_use_supply_uk unique (project_id, name);
 
 --changeset fcerny:3
 -- Do the same for revenue items, dropping first to aid in testing
-alter table bsa_revenue_item
-DROP constraint bsa_revenue_item_uk;
+-- Reference: https://docs.oracle.com/cd/B19306_01/server.102/b14237/statviews_1037.htm#i1576022
+declare 
+  l_count integer;
+begin
+    SELECT count(*) INTO l_count FROM USER_CONSTRAINTS 
+    WHERE CONSTRAINT_NAME='BSA_REVENUE_ITEM_UK';
+
+    if l_count > 0 then 
+        execute immediate 'alter table bsa_revenue_item drop constraint bsa_revenue_item_uk';
+    end if;
+end;
+/
 
 --changeset fcerny:4
 alter table bsa_revenue_item

--- a/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
+++ b/database/schema_updates/changelogs/20220418_supply_pkey_update.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset fcerny:1
+--changeset fcerny:1 endDelimiter:"/"
 declare 
   l_count integer;
 begin
@@ -13,12 +13,12 @@ begin
 end;
 /
 
---changest fcerny:2
+--changest fcerny:2 
 -- Add a new constraint back
 alter table bsa_single_use_supply
 ADD constraint bsa_single_use_supply_uk unique (project_id, name);
 
---changeset fcerny:3
+--changeset fcerny:3 endDelimiter:"/"
 -- Do the same for revenue items, dropping first to aid in testing
 -- Reference: https://docs.oracle.com/cd/B19306_01/server.102/b14237/statviews_1037.htm#i1576022
 declare 

--- a/tests/changelogs/test_revenue_item_validation.sql
+++ b/tests/changelogs/test_revenue_item_validation.sql
@@ -1,0 +1,67 @@
+--liquibase formatted sql
+
+--changeset fcerny:1 runOnChange:true endDelimiter:"/" stripComments:false
+create or replace package test_revenue_item_validation
+as
+    -- %suite(Test Revenue Item Validation)
+
+    --%test(Test Revenue Item Insert Same Name into Single Project)
+    --%throws(-1)
+    procedure test_revenue_item_insert_same_name_into_single_project;
+    --%test(Test Revenue Item Insert Same Name into Multiple Projects)
+    procedure test_revenue_item_insert_same_name_into_multi_project;
+end test_revenue_item_validation;
+/
+
+--changeset fcerny:2 runOnChange:true endDelimiter:"/" stripComments:false
+create or replace package body test_revenue_item_validation
+as
+    procedure test_revenue_item_insert_same_name_into_single_project is
+    projectId int;
+    platformSoldOnId int;
+    begin
+        -- Setup
+        -- Create a project
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('A very simple testing project!', 'Test Project 112233', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId FROM dev_ws.bsa_project p where p.title = 'Test Project 112233';
+
+        -- Get a platform sold on id for testing purposes
+        -- Reference: https://stackoverflow.com/questions/3451534/how-do-i-do-top-1-in-oracle
+        SELECT ID INTO platformSoldOnId from dev_ws.bsa_location where rownum = 1;
+
+        -- Act 
+        -- Attempt to insert a revenue item with the same name twice (should throw DUP_VAL_ON_INDEX)
+        INSERT INTO dev_ws.bsa_revenue_item (project_id, name, description, saleprice, platformsoldon, ispending, datesold)
+        VALUES (projectId, 'temp 12345', 'description', 5.50, platformSoldOnId, 'N', CURRENT_DATE);
+        INSERT INTO dev_ws.bsa_revenue_item (project_id, name, description, saleprice, platformsoldon, ispending, datesold)
+        VALUES (projectId, 'temp 12345', 'description', 7.50, platformSoldOnId, 'Y', CURRENT_DATE);
+    end;
+
+    procedure test_revenue_item_insert_same_name_into_multi_project is
+    projectId int;
+    projectId1 int;
+    platformSoldOnId int;
+    begin
+        -- Setup
+        -- Create two projects 
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('A very simple testing project!', 'Test Project 112233', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId FROM dev_ws.bsa_project p where p.title = 'Test Project 112233';
+
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('Project2 1122334', 'Project2 11223344', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId1 FROM dev_ws.bsa_project p where p.title = 'Project2 11223344';
+
+        -- Get a platform sold on id for testing purposes
+        SELECT ID INTO platformSoldOnId from dev_ws.bsa_location where rownum = 1;
+
+        -- Act 
+        -- Attempt to insert a revenue item with the same name into multiple projects (no error should be thrown)
+        INSERT INTO dev_ws.bsa_revenue_item (project_id, name, description, saleprice, platformsoldon, ispending, datesold)
+        VALUES (projectId, 'temp 12345', 'description', 5.50, platformSoldOnId, 'N', CURRENT_DATE);
+        INSERT INTO dev_ws.bsa_revenue_item (project_id, name, description, saleprice, platformsoldon, ispending, datesold)
+        VALUES (projectId1, 'temp 12345', 'description', 7.50, platformSoldOnId, 'Y', CURRENT_DATE);
+    end;
+end test_revenue_item_validation;
+/

--- a/tests/changelogs/test_single_use_supply_validation.sql
+++ b/tests/changelogs/test_single_use_supply_validation.sql
@@ -1,0 +1,67 @@
+--liquibase formatted sql
+
+--changeset fcerny:1 runOnChange:true endDelimiter:"/" stripComments:false
+create or replace package test_single_use_supply_validation
+as
+    -- %suite(Test Revenue Item Validation)
+
+    --%test(Test Revenue Item Insert Same Name into Single Project)
+    --%throws(-1)
+    procedure test_single_use_supply_insert_same_name_into_single_project;
+    --%test(Test Revenue Item Insert Same Name into Multiple Projects)
+    procedure test_single_use_supply_insert_same_name_into_multi_project;
+end test_single_use_supply_validation;
+/
+
+--changeset fcerny:2 runOnChange:true endDelimiter:"/" stripComments:false
+create or replace package body test_single_use_supply_validation
+as
+    procedure test_single_use_supply_insert_same_name_into_single_project is
+    projectId int;
+    platformSoldOnId int;
+    begin
+        -- Setup
+        -- Create a project
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('A very simple testing project!', 'Test Project 112233', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId FROM dev_ws.bsa_project p where p.title = 'Test Project 112233';
+
+        -- Get a platform sold on id for testing purposes
+        -- Reference: https://stackoverflow.com/questions/3451534/how-do-i-do-top-1-in-oracle
+        SELECT ID INTO platformSoldOnId from dev_ws.bsa_location where rownum = 1;
+
+        -- Act 
+        -- Attempt to insert a single use supply with the same name twice (should throw DUP_VAL_ON_INDEX)
+        INSERT INTO dev_ws.bsa_single_use_supply (name, description, datepurchased, project_id, ispending, unitcost, unitspurchased, revenueitem_id)
+        VALUES ('temp supply 12345', 'description', CURRENT_DATE, projectId, 'Y', 1.50, 10, null);
+        INSERT INTO dev_ws.bsa_single_use_supply (name, description, datepurchased, project_id, ispending, unitcost, unitspurchased, revenueitem_id)
+        VALUES ('temp supply 12345', 'description', CURRENT_DATE, projectId, 'Y', 1.50, 10, null);
+    end;
+
+    procedure test_single_use_supply_insert_same_name_into_multi_project is
+    projectId int;
+    projectId1 int;
+    platformSoldOnId int;
+    begin
+        -- Setup
+        -- Create two projects 
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('A very simple testing project!', 'Test Project 112233', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId FROM dev_ws.bsa_project p where p.title = 'Test Project 112233';
+
+        INSERT INTO dev_ws.bsa_project (description, title, datestarted, dateended)
+        VALUES ('Project2 1122334', 'Project2 11223344', CURRENT_DATE, NULL);
+        SELECT p.id INTO projectId1 FROM dev_ws.bsa_project p where p.title = 'Project2 11223344';
+
+        -- Get a platform sold on id for testing purposes
+        SELECT ID INTO platformSoldOnId from dev_ws.bsa_location where rownum = 1;
+
+        -- Act 
+        -- Attempt to insert a revenue item with the same name into multiple projects (no error should be thrown)
+        INSERT INTO dev_ws.bsa_single_use_supply (name, description, datepurchased, project_id, ispending, unitcost, unitspurchased, revenueitem_id)
+        VALUES ('temp supply 12345', 'description', CURRENT_DATE, projectId, 'Y', 1.50, 10, null);
+        INSERT INTO dev_ws.bsa_single_use_supply (name, description, datepurchased, project_id, ispending, unitcost, unitspurchased, revenueitem_id)
+        VALUES ('temp supply 12345', 'description', CURRENT_DATE, projectId1, 'Y', 1.50, 10, null);
+    end;
+end test_single_use_supply_validation;
+/


### PR DESCRIPTION
- Fixed single use supply and revenue item primary key issue where user could not add a single use supply with the same name in multiple projects

close #8 