### PR TITLE
Addng runOnChange = true to get around issue I created

### DIFF
--- a/database/schema_updates/changelogs/20220412_cleanup_packages.sql
+++ b/database/schema_updates/changelogs/20220412_cleanup_packages.sql
@@ -1,6 +1,7 @@
 --liquibase formatted sql
 
---changeset fcerny:1 endDelimiter:"/"
+-- I added runOnChange = true for this changeset only as I modified it after going to production which caused production deployment issues
+--changeset fcerny:1 endDelimiter:"/" runOnChange:true
 -- We renamed the test_trigger package to test_tool_triggers, so we need to drop it
 -- Reference: https://stackoverflow.com/questions/34151428/drop-trigger-only-if-it-exists-oracle
 declare 


### PR DESCRIPTION
- I manually pushed database changes because I updated an update script AFTER it had already been deployed to production (which is a no-no). The fix worked however